### PR TITLE
[Leia] fix standalone build with newer glm versions (>= 0.9.9.6) and update few other parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,13 @@ obj-x86_64-linux-gnu/
 # to prevent add after a "git format-patch VALUE" and "git add ." call
 /*.patch
 
+# Visual Studio Code
+.vscode
+
 # to prevent add if project code opened by Visual Studio over CMake file
 .vs/
+
+# General MacOS
+.DS_Store
+.AppleDouble
+.LSOverride

--- a/Findglm.cmake
+++ b/Findglm.cmake
@@ -1,0 +1,25 @@
+#.rst:
+# Findglm
+# ------------
+# Finds the OpenGL Mathematics (GLM) as a header only C++ mathematics library.
+#
+# This will define the following variables:
+#
+# GLM_FOUND - system has OpenGLES
+# GLM_INCLUDE_DIR - the OpenGLES include directory
+#
+# Note: Install was removed from GLM on version 0.9.9.6.
+
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_GLM glm QUIET)
+endif()
+
+find_path(GLM_INCLUDE_DIR glm.hpp
+                          PATHS ${PC_GLM_INCLUDEDIR}
+                          PATH_SUFFIXES glm)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(glm REQUIRED_VARS GLM_INCLUDE_DIR)
+
+mark_as_advanced(GLM_INCLUDE_DIR)

--- a/visualization.pictureit/addon.xml.in
+++ b/visualization.pictureit/addon.xml.in
@@ -9,8 +9,8 @@
         point="xbmc.player.musicviz"
         library_@PLATFORM@="@LIBRARY_FILENAME@"/>
     <extension point="xbmc.addon.metadata">
-        <summary lang="en">PictureIt - Kodi Visualization</summary>
-        <description lang="en">PictureIt is supposed to make listening to music more elegant and less flashy.
+        <summary lang="en_GB">PictureIt - Kodi Visualization</summary>
+        <description lang="en_GB">PictureIt is supposed to make listening to music more elegant and less flashy.
 The idea is to take random images YOU selected and display them alongside a simple spectrum at the bottom.
 Simple right?
 

--- a/visualization.pictureit/addon.xml.in
+++ b/visualization.pictureit/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
     id="visualization.pictureit"
-    version="3.0.1"
+    version="3.0.2"
     name="PictureIt"
     provider-name="linuxwhatelse">
     <requires>@ADDON_DEPENDS@</requires>

--- a/visualization.pictureit/addon.xml.in
+++ b/visualization.pictureit/addon.xml.in
@@ -24,7 +24,7 @@ Features:
 - Change the spectrums: Width, Bottom-Padding, Animation-Speed
         </description>
         <platform>@PLATFORM@</platform>
-        <license>GPL-2.0</license>
+        <license>GPL-2.0-or-later</license>
         <source>https://github.com/linuxwhatelse/visualization.pictureit</source>
         <forum>https://forum.kodi.tv/showthread.php?tid=236514</forum>
         <assets>


### PR DESCRIPTION
On GLM 0.9.9.6 they have removed for me not understandable reason the install on his cmake :roll_eyes:.

If now the addon becomes created as standalone (debian, gentoo... builds) the integated addon depends are not used and takes system installed ones, but as that there PkgConfig or cmake parts no more available, are them not found by `find_package(glm REQUIRED)`.

This add now a cmake find script about to allow further use of them.

Also are few other parts added where taken from Matrix branch.